### PR TITLE
Fixing example for web

### DIFF
--- a/example/fullstack_example/lib/main.dart
+++ b/example/fullstack_example/lib/main.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:fullstack_example/helpers/listener_service.dart';
@@ -11,6 +9,7 @@ import 'package:fullstack_example/widgets/select_image.dart';
 import 'package:fullstack_example/widgets/settings/settings.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:simple_painter/simple_painter.dart';
+import 'package:universal_io/io.dart';
 
 void main() {
   runApp(const MyApp());

--- a/example/fullstack_example/lib/widgets/select_image.dart
+++ b/example/fullstack_example/lib/widgets/select_image.dart
@@ -1,7 +1,6 @@
-import 'dart:io';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:universal_io/io.dart';
 
 class SelectImageDialog extends StatelessWidget {
   const SelectImageDialog({

--- a/example/fullstack_example/pubspec.yaml
+++ b/example/fullstack_example/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   phosphor_flutter: ^2.1.0
   simple_painter:
     path: ../..
+  universal_io: ^2.2.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Changing dart:io to universal_io

dart:io is not supported in web applications. universal_io is a cross-platform drop-in replacement for dart:io.

Changed two instances of the usage of dart:io in fullstack_example, and added universal_io to the pubspec of fullstack_example.

The example app now works correctly on the web.