### PR TITLE
Exposing models and allowing PositionModel changes to items

### DIFF
--- a/example/fullstack_example/lib/helpers/listener_service.dart
+++ b/example/fullstack_example/lib/helpers/listener_service.dart
@@ -23,6 +23,8 @@ class ListenerService {
           await changeImageItemValue(event.item as ImageItem);
         } else if (event.item is ShapeItem) {
           await changeShapeItemValue(event.item as ShapeItem);
+        } else if (event.item is CustomWidgetItem) {
+          await changeCustomWidgetValue(event.item as CustomWidgetItem);
         }
       }
     });
@@ -73,5 +75,29 @@ class ListenerService {
       newItem = item.copyWith(shapeType: ShapeType.values[type.index + 1]);
     }
     controller.changeShapeValues(newItem);
+  }
+
+  Future<void> changeCustomWidgetValue(CustomWidgetItem item) async {
+    var newItem = item;
+
+    newItem = item.copyWith(
+      widget: item.widget,
+      position: item.position,
+      borderRadius: item.borderRadius,
+      borderColor: item.borderColor,
+      borderWidth: item.borderWidth,
+      enableGradientColor: item.enableGradientColor,
+      gradientStartColor: item.gradientStartColor,
+      gradientEndColor: item.gradientEndColor,
+      enabled: item.enabled,
+      gradientBegin: item.gradientBegin,
+      gradientEnd: item.gradientEnd,
+      gradientOpacity: item.gradientOpacity,
+      size: item.size,
+      rotation: item.rotation,
+      layer: item.layer,
+    );
+
+    controller.changeCustomWidgetValues(newItem);
   }
 }

--- a/lib/simple_painter.dart
+++ b/lib/simple_painter.dart
@@ -8,4 +8,8 @@ export 'src/controllers/items/text_item.dart';
 export 'src/controllers/paint_actions/action_type_enum.dart';
 export 'src/controllers/painter_controller/painter_controller.dart';
 export 'src/controllers/settings/painter_settings.dart';
+export 'src/models/brush_model.dart';
+export 'src/models/position_model.dart';
+export 'src/models/render_item_model.dart';
+export 'src/models/size_model.dart';
 export 'src/views/widgets/painter_widget/painter_widget.dart';

--- a/lib/src/controllers/painter_controller/painter_controller_items/values/painter_controller_item_custom_widget_values.dart
+++ b/lib/src/controllers/painter_controller/painter_controller_items/values/painter_controller_item_custom_widget_values.dart
@@ -14,6 +14,7 @@ extension PainterControllerItemCustomWidgetValues on PainterController {
     AlignmentGeometry? gradientBegin,
     AlignmentGeometry? gradientEnd,
     double? gradientOpacity,
+    PositionModel? position,
   }) {
     final newItem = item.copyWith(
       widget: widget ?? item.widget,
@@ -26,6 +27,7 @@ extension PainterControllerItemCustomWidgetValues on PainterController {
       gradientBegin: gradientBegin ?? item.gradientBegin,
       gradientEnd: gradientEnd ?? item.gradientEnd,
       gradientOpacity: gradientOpacity ?? item.gradientOpacity,
+      position: position ?? item.position,
     );
     _changeItemValues(newItem);
   }

--- a/lib/src/controllers/painter_controller/painter_controller_items/values/painter_controller_item_image_values.dart
+++ b/lib/src/controllers/painter_controller/painter_controller_items/values/painter_controller_item_image_values.dart
@@ -14,6 +14,7 @@ extension PainterControllerItemImageValues on PainterController {
     AlignmentGeometry? gradientBegin,
     AlignmentGeometry? gradientEnd,
     double? gradientOpacity,
+    PositionModel? position,
   }) {
     final newItem = item.copyWith(
       fit: boxFit ?? item.fit,
@@ -26,6 +27,7 @@ extension PainterControllerItemImageValues on PainterController {
       gradientBegin: gradientBegin ?? item.gradientBegin,
       gradientEnd: gradientEnd ?? item.gradientEnd,
       gradientOpacity: gradientOpacity ?? item.gradientOpacity,
+      position: position ?? item.position,
     );
     _changeItemValues(newItem);
   }

--- a/lib/src/controllers/painter_controller/painter_controller_items/values/painter_controller_item_shape_values.dart
+++ b/lib/src/controllers/painter_controller/painter_controller_items/values/painter_controller_item_shape_values.dart
@@ -8,12 +8,14 @@ extension PainterControllerItemShapeValues on PainterController {
     Color? backgroundColor,
     Color? lineColor,
     double? thickness,
+    PositionModel? position,
   }) {
     final newItem = item.copyWith(
       shapeType: shapeType ?? item.shapeType,
       backgroundColor: backgroundColor ?? item.backgroundColor,
       lineColor: lineColor ?? item.lineColor,
       thickness: thickness ?? item.thickness,
+      position: position ?? item.position,
     );
     _changeItemValues(newItem);
   }

--- a/lib/src/controllers/painter_controller/painter_controller_items/values/painter_controller_item_text_values.dart
+++ b/lib/src/controllers/painter_controller/painter_controller_items/values/painter_controller_item_text_values.dart
@@ -11,6 +11,7 @@ extension PainterControllerItemTextValues on PainterController {
     Color? gradientEndColor,
     AlignmentGeometry? gradientBegin,
     AlignmentGeometry? gradientEnd,
+    PositionModel? position,
   }) {
     final newItem = item.copyWith(
       textStyle: textStyle ?? item.textStyle,
@@ -20,6 +21,7 @@ extension PainterControllerItemTextValues on PainterController {
       gradientEndColor: gradientEndColor ?? item.gradientEndColor,
       gradientBegin: gradientBegin ?? item.gradientBegin,
       gradientEnd: gradientEnd ?? item.gradientEnd,
+      position: position ?? item.position,
     );
     _changeItemValues(newItem);
   }


### PR DESCRIPTION
In order to programmatically manipulate the items' positions, it's necessary to have the model PositionModel exposed. I have take the liberty of exposing the other models as well.

In addition, the edit `change[X]Values` and `copyWith` functions have been updated to properly copy and update the new positions.