### PR TITLE
feat: PanGestureDetector for more precise draw input

### DIFF
--- a/lib/src/views/widgets/painter_widget/painter_widget.dart
+++ b/lib/src/views/widgets/painter_widget/painter_widget.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:simple_painter/simple_painter.dart';
 import 'package:simple_painter/src/controllers/custom_paint.dart';
@@ -15,6 +16,7 @@ part 'widgets/painter_widget_item_widget.dart';
 part 'widgets/painter_widget_drawing_widget.dart';
 part 'widgets/painter_widget_main_widget.dart';
 part 'widgets/painter_widget_viewer_widget.dart';
+part 'widgets/pan_gesture_detector_widget.dart';
 part 'items/painter_widget_image_item.dart';
 part 'items/painter_widget_shape_item.dart';
 part 'items/painter_widget_text_item.dart';

--- a/lib/src/views/widgets/painter_widget/widgets/painter_widget_drawing_widget.dart
+++ b/lib/src/views/widgets/painter_widget/widgets/painter_widget_drawing_widget.dart
@@ -14,7 +14,10 @@ class _DrawingWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     // GestureDetector is used to handle touch
     //interactions for drawing and erasing.
-    return GestureDetector(
+    return PanGestureDetector(
+      // The touchSlop property is set to 0 to
+      //allow for more precise touch interactions.
+      touchSlop: 0,
       // The onPanUpdate method is triggered
       //when the user moves their finger or stylus.
       onPanUpdate: (details) {

--- a/lib/src/views/widgets/painter_widget/widgets/pan_gesture_detector_widget.dart
+++ b/lib/src/views/widgets/painter_widget/widgets/pan_gesture_detector_widget.dart
@@ -1,0 +1,67 @@
+part of '../painter_widget.dart';
+
+// A simple stateless widget that detects pan gestures on its child.
+class PanGestureDetector extends StatelessWidget {
+  const PanGestureDetector({
+    super.key,
+    this.child,
+    this.behavior,
+    this.excludeFromSemantics = false,
+    this.semantics,
+    this.touchSlop,
+    this.onPanCancel,
+    this.onPanDown,
+    this.onPanEnd,
+    this.onPanStart,
+    this.onPanUpdate,
+  });
+
+  final Widget? child;
+
+  // Determines how hit tests behave.
+  final HitTestBehavior? behavior;
+
+  // Exclude the descendant widgets from the semantics tree if true.
+  final bool excludeFromSemantics;
+
+  // Custom semantics gesture logic.
+  final SemanticsGestureDelegate? semantics;
+
+  // The touch slop (distance the pointer must move to be recognized as a drag).
+  final double? touchSlop;
+
+  // Callbacks for handling various pan gesture states.
+  final GestureDragCancelCallback? onPanCancel;
+  final GestureDragDownCallback? onPanDown;
+  final GestureDragEndCallback? onPanEnd;
+  final GestureDragStartCallback? onPanStart;
+  final GestureDragUpdateCallback? onPanUpdate;
+
+  @override
+  Widget build(BuildContext context) {
+    return RawGestureDetector(
+      behavior: behavior,
+      excludeFromSemantics: excludeFromSemantics,
+      semantics: semantics,
+      gestures: {
+        PanGestureRecognizer:
+            GestureRecognizerFactoryWithHandlers<PanGestureRecognizer>(
+          // Create a PanGestureRecognizer with optional custom touch slop.
+          () => PanGestureRecognizer()
+            ..gestureSettings = DeviceGestureSettings(touchSlop: touchSlop),
+
+          // Set up the recognizer's callbacks.
+          (PanGestureRecognizer detector) {
+            detector
+              ..onDown = onPanDown
+              ..onStart = onPanStart
+              ..onUpdate = onPanUpdate
+              ..onEnd = onPanEnd
+              ..onCancel = onPanCancel;
+          },
+        )
+      },
+      child: child,
+    );
+  }
+}


### PR DESCRIPTION
Hardware input has no delay. But I felt slight delay while using my finger. I'm not sure if this one blocks a use case of the library. But worth giving a shot. Maybe you can adapt it with more flexibility. But it seems fair enough to reduce the pan start delay.